### PR TITLE
fix #24

### DIFF
--- a/src/pybacked/storagehandling/zip_handler.py
+++ b/src/pybacked/storagehandling/zip_handler.py
@@ -1,3 +1,4 @@
+import io
 import os
 import zipfile
 
@@ -40,7 +41,13 @@ def read_bin(archivepath, filelist):
         raise FileNotFoundError("Specified file does not exist")
     for filename in filelist:
         try:
-            datadict[filename] = archive.read(filename)
+            buffer = archive.open(filename)
+            wrapper = io.TextIOWrapper(buffer, newline=None)
+
+            datadict[filename] = wrapper.read()
+
+            wrapper.close()
+            buffer.close()
         except KeyError:
             datadict[filename] = None
     return datadict

--- a/tests/test_zip_handler.py
+++ b/tests/test_zip_handler.py
@@ -32,11 +32,15 @@ def test_read_bin():
     datadict = zip_handler.read_bin(archivepath, filelist)
 
     control_file1 = io.open(osp.abspath(datadir + filelist[0]), "rb")
-    control_data1 = control_file1.read()
+    control_file1_wrapper = io.TextIOWrapper(control_file1, newline=None)
+    control_data1 = control_file1_wrapper.read()
+    control_file1_wrapper.close()
     control_file1.close()
 
     control_file2 = io.open(osp.abspath(datadir + filelist[1]), "rb")
-    control_data2 = control_file2.read()
+    control_file2_wrapper = io.TextIOWrapper(control_file2, newline=None)
+    control_data2 = control_file2_wrapper.read()
+    control_file2_wrapper.close()
     control_file2.close()
 
     assertions = [False, False]


### PR DESCRIPTION
Fixes #24
Fixes the issue by using the io.TextIOWrapper to utilise the universal newline feature. This is done by setting the newline argument to `newline=None` (default setting)